### PR TITLE
Additionl feature and minor improvements to filter.sh

### DIFF
--- a/filter.sh
+++ b/filter.sh
@@ -30,29 +30,29 @@ katana -u "$website_url" -d 5 -f qurl | uro | anew "$output_dir/"$website_input"
 # XSS
 echo "Filtering URLs for potential XSS endpoints..."
 cat "$output_dir/"$website_input"/output.txt" | Gxss | kxss | grep -oP '^URL: \K\S+' | sed 's/=.*/=/' | sort -u > "$output_dir/xss_output.txt"
-echo "Extracting final filtered URLs to $output_dir/"$website_input"/xss_output.txt..."
+echo "Extracting final filtered XSS URLs to $output_dir/"$website_input"/xss_output.txt..."
 
 # Open Redirect
 echo "Filtering URLs for potential Open Redirect endpoints..."
 cat "$output_dir/"$website_input"/output.txt" | gf or | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/open_redirect_output.txt"
-echo "Extracting final filtered URLs to $output_dir/"$website_input"/open_redirect_output.txt..."
+echo "Extracting final filtered Open Redirect URLs to $output_dir/"$website_input"/open_redirect_output.txt..."
 
 # LFI
 echo "Filtering URLs for potential LFI endpoints..."
 cat "$output_dir/""$website_input""/output.txt" | gf lfi | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/lfi_output.txt"
-echo "Extracting final filtered URLs to $output_dir/"$website_input"/open_redirect_output.txt..."
+echo "Extracting final filtered LFI URLs to $output_dir/"$website_input"/open_redirect_output.txt..."
 
 # SQLi
 echo "Filtering URLs for potential SQLi endpoints..."
 cat "$output_dir/"$website_input"/output.txt" | gf sqli | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/sqli_output.txt"
-echo "Extracting final filtered URLs to $output_dir/"$website_input"/lfi_output.txt..."
+echo "Extracting final filtered SQLi URLs to $output_dir/"$website_input"/lfi_output.txt..."
 
 # Remove the intermediate file output/output.txt
-rm "$output_dir/output.txt"
+rm "$output_dir/"$website_input"/output.txt"
 
 # Notify the user that all tasks are complete
-echo "Filtered URLs have been saved to the respective output files in the 'output' directory:"
-echo "  - XSS: $output_dir/xss_output.txt"
-echo "  - Open Redirect: $output_dir/open_redirect_output.txt"
-echo "  - LFI: $output_dir/lfi_output.txt"
-echo "  - SQLi: $output_dir/sqli_output.txt"
+echo "Filtered URLs have been saved to the respective output files in the 'output/$website_input' directory:"
+echo "  - XSS: $output_dir/"$website_input"/xss_output.txt"
+echo "  - Open Redirect: $output_dir/"$website_input"/open_redirect_output.txt"
+echo "  - LFI: $output_dir/"$website_input"/lfi_output.txt"
+echo "  - SQLi: $output_dir/"$website_input"/sqli_output.txt"

--- a/filter.sh
+++ b/filter.sh
@@ -29,7 +29,7 @@ katana -u "$website_url" -d 5 -f qurl | uro | anew "$output_dir/"$website_input"
 
 # XSS
 echo "Filtering URLs for potential XSS endpoints..."
-cat "$output_dir/"$website_input"/output.txt" | Gxss | kxss | grep -oP '^URL: \K\S+' | sed 's/=.*/=/' | sort -u > "$output_dir/xss_output.txt"
+cat "$output_dir/"$website_input"/output.txt" | Gxss | kxss | grep -oP '^URL: \K\S+' | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/xss_output.txt"
 echo "Extracting final filtered XSS URLs to $output_dir/"$website_input"/xss_output.txt..."
 
 # Open Redirect

--- a/filter.sh
+++ b/filter.sh
@@ -10,49 +10,53 @@ else
     website_url="$website_input"
 fi
 
+# Extract Domain name from website url
+domain_name="${website_url#*://}"  # Remove the protocol
+domain_name="${domain_name%%/*}"     # Remove any path or query parameters
+
 # Inform the user of the normalized URL being used
 echo "Normalized URL being used: $website_url"
 
 # Create an output directory if it doesn't exist
 output_dir="output"
-mkdir -p "$output_dir/"$website_input""
+mkdir -p "$output_dir/$domain_name"
 
 # Step 1: Run katana with passive sources and save output to a unified file (output/output.txt)
 echo "Running katana with passive sources (waybackarchive, commoncrawl, alienvault)..."
-echo "$website_url" | katana -ps -pss waybackarchive,commoncrawl,alienvault -f qurl | uro > "$output_dir/"$website_input"/output.txt"
+echo "$website_url" | katana -ps -pss waybackarchive,commoncrawl,alienvault -f qurl | uro > "$output_dir/$domain_name/output.txt"
 
 # Step 2: Run katana actively with depth 5 and append results to output/output.txt
 echo "Running katana actively with depth 5..."
-katana -u "$website_url" -d 5 -f qurl | uro | anew "$output_dir/"$website_input"/output.txt"
+katana -u "$website_url" -d 5 -f qurl | uro | anew "$output_dir/$domain_name/output.txt"
 
 # Step 3: Filter output/output.txt for different vulnerabilities
 
 # XSS
 echo "Filtering URLs for potential XSS endpoints..."
-cat "$output_dir/"$website_input"/output.txt" | Gxss | kxss | grep -oP '^URL: \K\S+' | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/xss_output.txt"
-echo "Extracting final filtered XSS URLs to $output_dir/"$website_input"/xss_output.txt..."
+cat "$output_dir/$domain_name/output.txt" | Gxss | kxss | grep -oP '^URL: \K\S+' | sed 's/=.*/=/' | sort -u > "$output_dir/$domain_name/xss_output.txt"
+echo "Extracting final filtered XSS URLs to $output_dir/$domain_name/xss_output.txt..."
 
 # Open Redirect
 echo "Filtering URLs for potential Open Redirect endpoints..."
-cat "$output_dir/"$website_input"/output.txt" | gf or | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/open_redirect_output.txt"
-echo "Extracting final filtered Open Redirect URLs to $output_dir/"$website_input"/open_redirect_output.txt..."
+cat "$output_dir/$domain_name/output.txt" | gf or | sed 's/=.*/=/' | sort -u > "$output_dir/$domain_name/open_redirect_output.txt"
+echo "Extracting final filtered Open Redirect URLs to $output_dir/$domain_name/open_redirect_output.txt..."
 
 # LFI
 echo "Filtering URLs for potential LFI endpoints..."
-cat "$output_dir/""$website_input""/output.txt" | gf lfi | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/lfi_output.txt"
-echo "Extracting final filtered LFI URLs to $output_dir/"$website_input"/open_redirect_output.txt..."
+cat "$output_dir/$domain_name/output.txt" | gf lfi | sed 's/=.*/=/' | sort -u > "$output_dir/$domain_name/lfi_output.txt"
+echo "Extracting final filtered LFI URLs to $output_dir/$domain_name/lfi_output.txt..."
 
 # SQLi
 echo "Filtering URLs for potential SQLi endpoints..."
-cat "$output_dir/"$website_input"/output.txt" | gf sqli | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/sqli_output.txt"
-echo "Extracting final filtered SQLi URLs to $output_dir/"$website_input"/lfi_output.txt..."
+cat "$output_dir/$domain_name/output.txt" | gf sqli | sed 's/=.*/=/' | sort -u > "$output_dir/$domain_name/sqli_output.txt"
+echo "Extracting final filtered SQLi URLs to $output_dir/$domain_name/sqli_output.txt..."
 
 # Remove the intermediate file output/output.txt
-rm "$output_dir/"$website_input"/output.txt"
+rm "$output_dir/$domain_name/output.txt"
 
 # Notify the user that all tasks are complete
-echo "Filtered URLs have been saved to the respective output files in the 'output/$website_input' directory:"
-echo "  - XSS: $output_dir/"$website_input"/xss_output.txt"
-echo "  - Open Redirect: $output_dir/"$website_input"/open_redirect_output.txt"
-echo "  - LFI: $output_dir/"$website_input"/lfi_output.txt"
-echo "  - SQLi: $output_dir/"$website_input"/sqli_output.txt"
+echo "Filtered URLs have been saved to the respective output files in the 'output/$domain_name' directory:"
+echo "  - XSS: $output_dir/$domain_name/xss_output.txt"
+echo "  - Open Redirect: $output_dir/$domain_name/open_redirect_output.txt"
+echo "  - LFI: $output_dir/$domain_name/lfi_output.txt"
+echo "  - SQLi: $output_dir/$domain_name/sqli_output.txt"

--- a/filter.sh
+++ b/filter.sh
@@ -15,34 +15,37 @@ echo "Normalized URL being used: $website_url"
 
 # Create an output directory if it doesn't exist
 output_dir="output"
-mkdir -p "$output_dir"
+mkdir -p "$output_dir/"$website_input""
 
 # Step 1: Run katana with passive sources and save output to a unified file (output/output.txt)
 echo "Running katana with passive sources (waybackarchive, commoncrawl, alienvault)..."
-echo "$website_url" | katana -ps -pss waybackarchive,commoncrawl,alienvault -f qurl | uro > "$output_dir/output.txt"
+echo "$website_url" | katana -ps -pss waybackarchive,commoncrawl,alienvault -f qurl | uro > "$output_dir/"$website_input"/output.txt"
 
 # Step 2: Run katana actively with depth 5 and append results to output/output.txt
 echo "Running katana actively with depth 5..."
-katana -u "$website_url" -d 5 -f qurl | uro | anew "$output_dir/output.txt"
+katana -u "$website_url" -d 5 -f qurl | uro | anew "$output_dir/"$website_input"/output.txt"
 
 # Step 3: Filter output/output.txt for different vulnerabilities
 
 # XSS
 echo "Filtering URLs for potential XSS endpoints..."
-cat "$output_dir/output.txt" | Gxss | kxss | grep -oP '^URL: \K\S+' | sed 's/=.*/=/' | sort -u > "$output_dir/xss_output.txt"
-echo "Extracting final filtered URLs to $output_dir/xss_output.txt..."
+cat "$output_dir/"$website_input"/output.txt" | Gxss | kxss | grep -oP '^URL: \K\S+' | sed 's/=.*/=/' | sort -u > "$output_dir/xss_output.txt"
+echo "Extracting final filtered URLs to $output_dir/"$website_input"/xss_output.txt..."
 
 # Open Redirect
 echo "Filtering URLs for potential Open Redirect endpoints..."
-cat "$output_dir/output.txt" | gf or | sed 's/=.*/=/' | sort -u > "$output_dir/open_redirect_output.txt"
+cat "$output_dir/"$website_input"/output.txt" | gf or | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/open_redirect_output.txt"
+echo "Extracting final filtered URLs to $output_dir/"$website_input"/open_redirect_output.txt..."
 
 # LFI
 echo "Filtering URLs for potential LFI endpoints..."
-cat "$output_dir/output.txt" | gf lfi | sed 's/=.*/=/' | sort -u > "$output_dir/lfi_output.txt"
+cat "$output_dir/""$website_input""/output.txt" | gf lfi | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/lfi_output.txt"
+echo "Extracting final filtered URLs to $output_dir/"$website_input"/open_redirect_output.txt..."
 
 # SQLi
 echo "Filtering URLs for potential SQLi endpoints..."
-cat "$output_dir/output.txt" | gf sqli | sed 's/=.*/=/' | sort -u > "$output_dir/sqli_output.txt"
+cat "$output_dir/"$website_input"/output.txt" | gf sqli | sed 's/=.*/=/' | sort -u > "$output_dir/"$website_input"/sqli_output.txt"
+echo "Extracting final filtered URLs to $output_dir/"$website_input"/lfi_output.txt..."
 
 # Remove the intermediate file output/output.txt
 rm "$output_dir/output.txt"


### PR DESCRIPTION
A- Adjusted output directory from "output" to "output/domain_name" to be able to run the tool on different targets without overwriting previously filtered data and organize output results per domain name in output folder.

B- Added filtering status notes for open redirect, lfi and sqli. It was only for XXS filtering status previously.

C- Added details for each filtering status to indicate specific stage of filtering.